### PR TITLE
eliminate the border line of iframe

### DIFF
--- a/user-guide/likecoin-button/jekyll.md
+++ b/user-guide/likecoin-button/jekyll.md
@@ -42,7 +42,7 @@ https://button.like.co/in/embed/{{site.liker_id}}/button?referrer={{ page.url | 
 ```text
 {% if site.liker_id %}
 <iframe
-  style="width: 100%; max-width: 485px; height: 240px; margin: auto; overflow: hidden; display: block;"
+  style="width: 100%; max-width: 485px; height: 240px; margin: auto; overflow: hidden; display: block; border: 0;"
   src="https://button.like.co/in/embed/{{site.liker_id}}/button?referrer={{ page.url | absolute_url | cgi_escape }}">
 </iframe>
 {% endif %}


### PR DESCRIPTION
The original iframe style may display frame border.
I add an argument `border: 0` to fix the problem. Make the iframe looks cleaner.

Here is the effect I tried on my Jekyll blog: https://laiyenju.github.io/datanews-0